### PR TITLE
アクセシビリティを考慮するように改善した

### DIFF
--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -5,9 +5,11 @@ import App from "../App";
 test("Todoアプリ画面を表示する", () => {
   render(<App />);
   // やることの追加フォームの表示
-  expect(screen.getByPlaceholderText(/やることを/)).toBeInTheDocument();
+  expect(
+    screen.getByRole("textbox", { name: "input-todo" })
+  ).toBeInTheDocument();
   // やることリストの表示
-  expect(screen.getByTestId("todo-list")).toBeInTheDocument();
+  expect(screen.getByRole("list", { name: "list-todo" })).toBeInTheDocument();
   // やることリストの操作エリアの表示
   const operationTitles = [
     "Actions",

--- a/src/__tests__/todo/todoList/TodoItem.test.tsx
+++ b/src/__tests__/todo/todoList/TodoItem.test.tsx
@@ -49,7 +49,8 @@ describe("初期選択状態のテスト", () => {
     ${"　"}
   `("TodoText $text が表示される", ({ text }) => {
     render(<TodoItem id={"dummy-id"} text={text} />);
-    const textBox = screen.getByTestId("todo-text");
+    // getByTextだとスペースと空文字が特定できないのでtext表示エリアを指定してtextContentで比較する
+    const textBox = screen.getByLabelText("content-todo");
     expect(textBox.textContent).toBe(text);
   });
 });

--- a/src/__tests__/todo/todoList/TodoList.test.tsx
+++ b/src/__tests__/todo/todoList/TodoList.test.tsx
@@ -19,7 +19,7 @@ describe("Todoの件数による表示テスト", () => {
       },
     ];
     render(<TodoList todos={todos} />);
-    const todoTexts = screen.getAllByTestId("todo-text");
+    const todoTexts = screen.getAllByLabelText("content-todo");
     expect(todoTexts).toHaveLength(1);
     expect(todoTexts[0].textContent).toBe(text.text);
   });
@@ -36,7 +36,7 @@ describe("Todoの件数による表示テスト", () => {
       },
     ];
     render(<TodoList todos={todos} />);
-    const todoTexts = screen.getAllByTestId("todo-text");
+    const todoTexts = screen.getAllByLabelText("content-todo");
     expect(todoTexts).toHaveLength(2);
     todoTexts.forEach((todoText, index) => {
       expect(todoText.textContent).toBe(expectTexts[index]);
@@ -45,7 +45,7 @@ describe("Todoの件数による表示テスト", () => {
 
   test("Todoが0件ならリストは表示されない", () => {
     render(<TodoList todos={[]} />);
-    const todoTexts = screen.queryByTestId("todo-text");
-    expect(todoTexts).toBeNull();
+    const todoTexts = screen.queryAllByLabelText("content-todo");
+    expect(todoTexts).toHaveLength(0);
   });
 });

--- a/src/todo/operating/RemainingTodos.tsx
+++ b/src/todo/operating/RemainingTodos.tsx
@@ -2,7 +2,9 @@ const RemainingTodos = ({ numOfTodo }: { numOfTodo: number }) => {
   return (
     <div>
       <h5>Remaining Todos</h5>
-      <div>{`${numOfTodo} remain${numOfTodo > 1 ? "s" : ""} left`}</div>
+      <div aria-label={"remaining-todos"}>
+        {`${numOfTodo} remain${numOfTodo > 1 ? "s" : ""} left`}
+      </div>
     </div>
   );
 };

--- a/src/todo/todoList/TodoItem.tsx
+++ b/src/todo/todoList/TodoItem.tsx
@@ -18,7 +18,7 @@ const TodoItem = (todo: Todo) => {
           onChange={(event) => ""}
         />
       </span>
-      <span data-testid={"todo-text"}>{todo.text}</span>
+      <span aria-label={"content-todo"}>{todo.text}</span>
       <span>
         <select value={todo.color} onChange={(event) => ""}>
           <option value="" />

--- a/src/todo/todoList/TodoList.tsx
+++ b/src/todo/todoList/TodoList.tsx
@@ -3,7 +3,7 @@ import { Todo } from "../model/todo/Todo";
 
 const TodoList = ({ todos }: { todos: Array<Todo> }) => {
   return (
-    <ul data-testid={"todo-list"}>
+    <ul aria-label={"list-todo"}>
       {todos.map((todo) => (
         <TodoItem
           key={todo.id}


### PR DESCRIPTION
Testing-library の [priority](https://testing-library.com/docs/queries/about#priority) を意識して、`*ByRole` で特定できるように工夫する。
インタラクティブではないテキストを表示するだけの要素は、`*ByText`で取得するか、一意に特定できなければ `aria-label`を付けて `*ByLabelText` で要素を取得してからtextContentで検証するようにした
