### PR TITLE
TodoColorの選択状態を制御できるように準備した

### DIFF
--- a/src/__tests__/todo/model/todo/Todo.test.ts
+++ b/src/__tests__/todo/model/todo/Todo.test.ts
@@ -1,4 +1,5 @@
 import { createTodo, Todo } from "../../../../todo/model/todo/Todo";
+import { TODO_COLOR } from "../../../../todo/model/filter/TodoColors";
 
 describe("Todoの作成テスト", () => {
   test("TodoTextを渡すとIDにULIDをセットしてTodoオブジェクトを作成する", () => {
@@ -7,7 +8,7 @@ describe("Todoの作成テスト", () => {
     expect(todo.id).toMatch(/^[0-9A-Z]{26}$/);
     expect(todo.text).toBe(newText);
     expect(todo.isCompleted).toBeFalsy();
-    expect(todo.color).toBeUndefined();
+    expect(todo.color).toBe(TODO_COLOR.None);
   });
 
   test("IDは重複しないこと", () => {

--- a/src/__tests__/todo/operating/ColorFilter.test.tsx
+++ b/src/__tests__/todo/operating/ColorFilter.test.tsx
@@ -22,7 +22,7 @@ describe("カラーフィルターの初期値", () => {
       screen
         .getAllByRole("checkbox", { checked: false })
         .map((e) => e.getAttribute("name"))
-    ).toEqual(["blue", "orange", "red"]);
+    ).toEqual(["", "blue", "orange", "red"]);
   });
 
   test("パラメータが渡されない場合は全て未選択であること", () => {

--- a/src/__tests__/todo/todoList/TodoItem.test.tsx
+++ b/src/__tests__/todo/todoList/TodoItem.test.tsx
@@ -20,6 +20,7 @@ describe("初期選択状態のテスト", () => {
             id: "dummy-id",
             text: "Test whether todo is checked or not",
             isCompleted: isCompleted,
+            color: TODO_COLOR.None,
           }}
           updateComplete={updateComplete}
         />
@@ -31,6 +32,7 @@ describe("初期選択状態のテスト", () => {
 
   test.each`
     todoColor            | displayValue
+    ${TODO_COLOR.None}   | ${capitalize(TODO_COLOR.None)}
     ${TODO_COLOR.Green}  | ${capitalize(TODO_COLOR.Green)}
     ${TODO_COLOR.Purple} | ${capitalize(TODO_COLOR.Purple)}
     ${TODO_COLOR.Red}    | ${capitalize(TODO_COLOR.Red)}
@@ -51,6 +53,7 @@ describe("初期選択状態のテスト", () => {
           todo={{
             id: "dummy-id",
             text: "Test SelectBox",
+            isCompleted: false,
             color: todoColor,
           }}
           updateComplete={updateComplete}
@@ -75,6 +78,8 @@ describe("初期選択状態のテスト", () => {
         todo={{
           id: "dummy-id",
           text: text,
+          isCompleted: false,
+          color: TODO_COLOR.None,
         }}
         updateComplete={updateComplete}
       />
@@ -106,6 +111,7 @@ describe("Todoの完了状況が操作できること", () => {
             id: id,
             text: "update isChecked",
             isCompleted: isCompleted,
+            color: TODO_COLOR.None,
           }}
           updateComplete={updateComplete}
         />

--- a/src/__tests__/todo/todoList/TodoList.test.tsx
+++ b/src/__tests__/todo/todoList/TodoList.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import TodoList from "../../../todo/todoList/TodoList";
 import { Todo } from "../../../todo/model/todo/Todo";
 import userEvent from "@testing-library/user-event";
+import { TODO_COLOR } from "../../../todo/model/filter/TodoColors";
 
 const updateComplete: jest.Mock = jest.fn();
 
@@ -19,6 +20,8 @@ describe("Todoの件数による表示テスト", () => {
       {
         id: "dummy",
         text: text,
+        isCompleted: false,
+        color: TODO_COLOR.None,
       },
     ];
     render(<TodoList todos={todos} updateComplete={updateComplete} />);
@@ -32,10 +35,14 @@ describe("Todoの件数による表示テスト", () => {
       {
         id: "dummy-1",
         text: expectTexts[0],
+        isCompleted: false,
+        color: TODO_COLOR.None,
       },
       {
         id: "dummy-2",
         text: expectTexts[1],
+        isCompleted: false,
+        color: TODO_COLOR.None,
       },
     ];
     render(<TodoList todos={todos} updateComplete={updateComplete} />);
@@ -73,6 +80,7 @@ describe("Todoの状況を更新する", () => {
           id,
           text: "完了チェックのテスト",
           isCompleted,
+          color: TODO_COLOR.None,
         },
       ];
       render(<TodoList todos={todos} updateComplete={updateComplete} />);

--- a/src/todo/model/filter/TodoColors.ts
+++ b/src/todo/model/filter/TodoColors.ts
@@ -1,5 +1,6 @@
 // Enumの代わりにconstアサーション(as const)でCOLORオブジェクトをreadonlyにする
 export const TODO_COLOR = {
+  None: "",
   Green: "green",
   Blue: "blue",
   Orange: "orange",

--- a/src/todo/model/todo/Todo.ts
+++ b/src/todo/model/todo/Todo.ts
@@ -1,15 +1,16 @@
-import { TodoColor } from "../filter/TodoColors";
+import { TODO_COLOR, TodoColor } from "../filter/TodoColors";
 import { ulid } from "ulid";
 
 export interface Todo {
   id: string;
   text: string;
-  isCompleted?: boolean | false;
-  color?: TodoColor;
+  isCompleted: boolean;
+  color: TodoColor;
 }
 
 export const createTodo = (newText: string): Todo => ({
   id: ulid(),
   text: newText,
   isCompleted: false,
+  color: TODO_COLOR.None,
 });

--- a/src/todo/todoList/TodoItem.tsx
+++ b/src/todo/todoList/TodoItem.tsx
@@ -32,7 +32,6 @@ const TodoItem = ({
           value={todo.color}
           onChange={(event) => ""}
         >
-          <option value="" />
           {optionalColors}
         </select>
       </span>


### PR DESCRIPTION
SelectBoxに渡すTodoColorがundefinedだと制御状態にできていなかった。

TODO_COLORに未選択状態を表すプロパティを追加しすることで、SelectBoxのOptionを全て表現するようにした。

TODOインタフェースのプロパティは全てOptionalを外して、TODO_COLORの選択を必須としました。