### PR TITLE
Node18.x系でStorybook6.xをビルドするとOpenSSL互換エラーが発生する問題に対応

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,3 +38,5 @@ jobs:
         uses: chromaui/action@v1
         with:
           projectToken: ${{secrets.CHROMATIC_PROJECT_TOKEN}}
+        env:
+          NODE_OPTIONS: "--max-old-space-size=15360"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,5 +38,3 @@ jobs:
         uses: chromaui/action@v1
         with:
           projectToken: ${{secrets.CHROMATIC_PROJECT_TOKEN}}
-        env:
-          NODE_OPTIONS: "--openssl-legacy-provider"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,9 +34,7 @@ jobs:
       - name: Run Jest
         run: yarn test --silent
 
-      - name: Run Chromatic
-        uses: chromaui/action@v1
-        with:
-          projectToken: ${{secrets.CHROMATIC_PROJECT_TOKEN}}
-        env:
-          NODE_OPTIONS: "--max-old-space-size=15360"
+#      - name: Run Chromatic
+#        uses: chromaui/action@v1
+#        with:
+#          projectToken: ${{secrets.CHROMATIC_PROJECT_TOKEN}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,9 +34,9 @@ jobs:
       - name: Run Jest
         run: yarn test --silent
 
-#      - name: Run Chromatic
-#        uses: chromaui/action@v1
-#        with:
-#          projectToken: ${{secrets.CHROMATIC_PROJECT_TOKEN}}
-#        env:
-#          NODE_OPTIONS: "--max-old-space-size=15360 --openssl-legacy-provider"
+      - name: Run Chromatic
+        uses: chromaui/action@v1
+        with:
+          projectToken: ${{secrets.CHROMATIC_PROJECT_TOKEN}}
+        env:
+          NODE_OPTIONS: "--openssl-legacy-provider"

--- a/package.json
+++ b/package.json
@@ -77,8 +77,8 @@
     "preview": "vite preview",
     "test": "jest --coverage",
     "eslint": "eslint . --ext .js,.jsx,.ts,.tsx",
-    "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
+    "storybook": "NODE_OPTIONS=--openssl-legacy-provider start-storybook -p 6006",
+    "build-storybook": "NODE_OPTIONS=--openssl-legacy-provider build-storybook",
     "snapshot": "yarn test ./src/__tests__/Storyshots.test.ts"
   },
   "browserslist": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6518,9 +6518,9 @@ es5-shim@^4.5.13:
   integrity sha512-jg21/dmlrNQI7JyyA2w7n+yifSxBng0ZralnSfVZjoCawgNTCnS+yBCyVM9DL5itm7SUnDGgv7hcq2XCZX4iRQ==
 
 es6-shim@^0.35.5:
-  version "0.35.6"
-  resolved "https://registry.yarnpkg.com/es6-shim/-/es6-shim-0.35.6.tgz#d10578301a83af2de58b9eadb7c2c9945f7388a0"
-  integrity sha512-EmTr31wppcaIAgblChZiuN/l9Y7DPyw8Xtbg7fIVngn6zMW+IEBJDJngeKC3x6wr0V/vcA2wqeFnaw1bFJbDdA==
+  version "0.35.7"
+  resolved "https://registry.yarnpkg.com/es6-shim/-/es6-shim-0.35.7.tgz#db00f1cbb7d4de70b50dcafa45b157e9ba28f5d2"
+  integrity sha512-baZkUfTDSx7X69+NA8imbvGrsPfqH0MX7ADdIDjqwsI8lkTgLIiD2QWrUCSGsUQ0YMnSCA/4pNgSyXdnLHWf3A==
 
 esbuild@^0.16.3:
   version "0.16.10"


### PR DESCRIPTION
## 前提

この対応は Storybook7.xに上げるまでの暫定対応の予定

## 概要

Node.jsを 16から18に上げて、StorybookをビルドするとOpenSSLのEOLバージョンを利用していることからエラーが発生する

`code: 'ERR_OSSL_EVP_UNSUPPORTED'`

これに対処するために StorybookのBuild実行時に 環境変数 `NODE_OPTIONS=--openssl-legacy-provider` を指定して エラーをスキップするようにしている

尚、Storybook7.x にUpdateすることでビルド時に利用する OpenSSLのバージョンがサポート対象に上げられるためこの対応は不要になる予定。