### PR TITLE
react-testing-library の依存関係設定を見直した

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
     "@storybook/react-vite": "^7.0.0-beta.50",
     "@storybook/testing-library": "^0.0.14-next.1",
     "@storybook/testing-react": "^2.0.0-next.0",
+    "@testing-library/dom": "^9.0.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
-    "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^14.4.3",
     "@types/jest": "^29.4.0",
     "@types/node": "^18.14.0",
@@ -67,7 +67,7 @@
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.5",
-    "vite": "^4.1.2"
+    "vite": "^4.1.3"
   },
   "resolutions": {
     "react-test-renderer": "^18.2.0"

--- a/src/__tests__/todo/TodoApp.test.tsx
+++ b/src/__tests__/todo/TodoApp.test.tsx
@@ -60,7 +60,7 @@ describe("Todoリストの操作テスト", () => {
       ]);
 
       // When: ２番目のTodoを完了にする
-      await page.completeTodo(2, true);
+      await page.completeTodo(2);
 
       // Then: ２番目だけが完了になっていること
       expect(await TodoListPage.isCompletedTodoByRow(1)).toBe(false);
@@ -85,7 +85,7 @@ describe("Todoリストの操作テスト", () => {
       ]);
 
       // When: ２番目のTodoの完了操作を行う
-      await page.completeTodo(2, false);
+      await page.completeTodo(2);
 
       // Then: ２番目が未完了に戻る
       expect(await TodoListPage.isCompletedTodoByRow(2)).toBe(false);
@@ -321,7 +321,7 @@ describe("Todoリストの操作テスト", () => {
         );
 
         // When: １番目のTodoを完了済みにする
-        await page.completeTodo(1, true);
+        await page.completeTodo(1);
 
         // Then: Remaining Todoの表示件数はTodoリストの件数から１件少なくなる
         expect(await TodoListPage.countTodos()).toBe(initialCount);
@@ -356,7 +356,7 @@ describe("Todoリストの操作テスト", () => {
         expect(await TodoListPage.isContentRemainingTodos(initCount - 2)).toBeTruthy();
 
         // When: １番目のTodoを未完了に戻す
-        await page.completeTodo(1, false);
+        await page.completeTodo(1);
 
         // Then: Remaining Todoの表示件数は１件増えること
         expect(await TodoListPage.countTodos()).toBe(initCount);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2819,14 +2819,6 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
-"@testing-library/react-hooks@^8.0.1":
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
-  integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    react-error-boundary "^3.1.0"
-
 "@testing-library/react@^14.0.0":
   version "14.0.0"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-14.0.0.tgz#59030392a6792450b9ab8e67aea5f3cc18d6347c"
@@ -4186,9 +4178,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001449:
-  version "1.0.30001456"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001456.tgz#734ec1dbfa4f3abe6e435b78ecf40d68e8c32ce4"
-  integrity sha512-XFHJY5dUgmpMV25UqaD4kVq2LsiaU5rS8fb0f17pCoXQiQslzmFgnfOxfvo1bTpTqf7dwG/N/05CnLCnOEKmzA==
+  version "1.0.30001457"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001457.tgz#6af34bb5d720074e2099432aa522c21555a18301"
+  integrity sha512-SDIV6bgE1aVbK6XyxdURbUE89zY7+k1BBBaOwYwkNCglXlel/E7mELiHC64HQ+W0xSKlqWhV9Wh7iHxUjMs4fA==
 
 chalk@4.1.1:
   version "4.1.1"
@@ -8596,13 +8588,6 @@ react-element-to-jsx-string@^15.0.0:
     is-plain-object "5.0.0"
     react-is "18.1.0"
 
-react-error-boundary@^3.1.0:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
-  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-
 react-inspector@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-6.0.1.tgz#1a37f0165d9df81ee804d63259eaaeabe841287d"
@@ -8956,9 +8941,9 @@ rimraf@~2.6.2:
     glob "^7.1.3"
 
 "rollup@^2.25.0 || ^3.3.0", rollup@^3.10.0:
-  version "3.17.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.17.0.tgz#f5ab5ffc16838a4732f6f71f7f58ffd96e6521d1"
-  integrity sha512-0zZQ0J4p0ZtTla6l8sheDTUyNfGZQDpU5h0nPHf6xtUXIzKK70LmB2IRR0wLnzaL8a02fjmsJy+XCncbSwOpjg==
+  version "3.17.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.17.2.tgz#a4ecd29c488672a0606e41ef57474fad715750a9"
+  integrity sha512-qMNZdlQPCkWodrAZ3qnJtvCAl4vpQ8q77uEujVCCbC/6CLB7Lcmvjq7HyiOSnf4fxTT9XgsE36oLHJBH49xjqA==
   optionalDependencies:
     fsevents "~2.3.2"
 
@@ -10024,10 +10009,10 @@ vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
 
-vite@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-4.1.2.tgz#6908882984e490c44c28e784a2c52de556f04b41"
-  integrity sha512-MWDb9Rfy3DI8omDQySbMK93nQqStwbsQWejXRY2EBzEWKmLAXWb1mkI9Yw2IJrc+oCvPCI1Os5xSSIBYY6DEAw==
+vite@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-4.1.3.tgz#001a038c3a7757d532787c0de429b8368136ded5"
+  integrity sha512-0Zqo4/Fr/swSOBmbl+HAAhOjrqNwju+yTtoe4hQX9UsARdcuc9njyOdr6xU0DDnV7YP0RT6mgTTOiRtZgxfCxA==
   dependencies:
     esbuild "^0.16.14"
     postcss "^8.4.21"


### PR DESCRIPTION
## 概要

* @testing-library/dom を明示的に追加インストールするようにした
* @testing-library/react-hook をpackage.jsonから除去した
* viteを最新バージョンに更新し、依存関係を更新したs

## 説明

@testing-library/user-event を利用するときは、@testing-library/dom も必要だったのだが追加していなかったので古いバージョンのライブラリが使われていた。
参考：* [公式ドキュメント](https://testing-library.com/docs/user-event/install) 
このために次のような問題が発生していた模様

* TodoListPageにおいてユーザーイベント操作後に不必要なWait処理を入れる必要があった
  * React18 に上げた時にこれがないとテストが失敗していたのだが、dom-testing-libraryを最新にすることで、不要だったり、却ってテストが失敗することになっていた。
* react-testing-library を 14.0.0 に上げた際に発生していた、fireEventに `act()` で囲んでasync/await 対応を行う旨の警告が表示されなくなったので、古いdom-testing-library を利用していたのが原因だったと考える

react-hook-testing-library は、React18 に合わせて react-testing-library に包括されたのでpackage.jsonから削除するべきだったため。
参考: [GitHub repo](https://github.com/testing-library/react-hooks-testing-library#a-note-about-react-18-support)
これによるプログラムへの影響は無かったが、yarn install などで警告が出ていた

